### PR TITLE
Add connector version and SQLCompatibilitySettings

### DIFF
--- a/ClickHouseConnector.pq
+++ b/ClickHouseConnector.pq
@@ -2,9 +2,9 @@
 // based on an ODBC driver. It is meant as a template for other
 // ODBC based connectors that require similar functionality.
 //
-[Version = "0.1.4"]
+[Version = "0.1.5"]
 section ClickHouse;
-ConnectorVersion = "0.1.4";
+ConnectorVersion = "0.1.5";
 
 // When set to true, additional trace information will be written out to the User log.
 // This should be set to false before release. Tracing is done through a call to

--- a/ClickHouseConnector.pq
+++ b/ClickHouseConnector.pq
@@ -1,9 +1,10 @@
-﻿// This connector provides a sample Direct Query enabled connector
+// This connector provides a sample Direct Query enabled connector
 // based on an ODBC driver. It is meant as a template for other
 // ODBC based connectors that require similar functionality.
 //
 [Version = "0.1.4"]
 section ClickHouse;
+ConnectorVersion = "0.1.4";
 
 // When set to true, additional trace information will be written out to the User log.
 // This should be set to false before release. Tracing is done through a call to
@@ -266,6 +267,8 @@ let
 
             Port = port ,
             Database = database,  
+            ClientName = "PowerBi/" & ConnectorVersion,
+            SQLCompatibilitySettings = 1,
             
             // These fields come from the options record, so they might be null.
             // A later step will strip all null values from the connection string.


### PR DESCRIPTION
Add extra parameters to the ODBC connection string:

- ClientVersion: that reports the connector version to the driver
- SQLCompatibilitySettings: to instruct the driver to enable extra compatibility settings such as `prefer_column_name_to_alias` and `cast_keep_nullable`.

The `SQLCompatibilitySettings` option of the ODBC driver is currently in development. Since we do not know how long certification will take, we can already pass this option to the driver. For any driver version that does not support this option, `SQLCompatibilitySettings` will be ignored.